### PR TITLE
Backport changes from trunk.

### DIFF
--- a/src/Appdefs.h
+++ b/src/Appdefs.h
@@ -81,7 +81,8 @@ enum
     ID_ANNOT18,
     ID_ANNOT19,
     ID_ANNOT20,
-    ID_CMD_ABOUT = wxID_ABOUT   // important for possible Mac port that we use this apparently
+    ID_CMD_ABOUT = wxID_ABOUT,   // important for possible Mac port that we use this apparently
+    ID_COPY_GAME_PGN_TO_CLIPBOARD
 };
 
 //-----------------------------------------------------------------------------

--- a/src/CtrlBox2.cpp
+++ b/src/CtrlBox2.cpp
@@ -23,7 +23,7 @@ BEGIN_EVENT_TABLE( CtrlBox2, wxTextCtrl )
     EVT_SET_CURSOR(CtrlBox2::OnSetCursor)
     EVT_LEFT_DOWN (CtrlBox2::OnMouseLeftDown)
 //    EVT_MOTION (CtrlBox2::OnMouseMove)
-    EVT_ERASE_BACKGROUND(CtrlBox2::OnEraseBackground)
+    EVT_ERASE_BACKGROUND(CtrlBox2::OnEraseBackGround)
 //    EVT_TIMER( TIMER_ID, CtrlBox2::OnTimeout)
 END_EVENT_TABLE()
 

--- a/src/GameLogic.cpp
+++ b/src/GameLogic.cpp
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <time.h>
 #include "wx/wx.h"
+#include "wx/clipbrd.h"
 #include "wx/listctrl.h"
 #include "wx/filename.h"
 #include "Appdefs.h"
@@ -1220,6 +1221,24 @@ void GameLogic::CmdEditGameDetails()
     if( okay )
         GameRedisplayPlayersResult();        
     StatusUpdate();
+}
+
+void GameLogic::CmdEditCopyGamePGNToClipboard()
+{
+    if (gd.IsEmpty()) return;
+
+    gd.FleshOutDate();
+    gd.FleshOutMoves();
+    std::string head;
+    gd.ToFileTxtGameDetails(head);
+    std::string body;
+    gd.ToFileTxtGameBody(body);
+
+    if (wxTheClipboard->Open())
+    {
+        wxTheClipboard->SetData(new wxTextDataObject(head + body));
+        wxTheClipboard->Close();
+    }
 }
 
 // If players or result (possibly) changed, redisplay it

--- a/src/GameLogic.h
+++ b/src/GameLogic.h
@@ -93,6 +93,7 @@ public:
     void CmdPlayers();
     void CmdClocks();
     void CmdEditGameDetails();
+    void CmdEditCopyGamePGNToClipboard();
     void CmdEditPromote();
     void CmdEditDemote();
     void CmdEditPromoteToVariation();

--- a/src/Rybka.cpp
+++ b/src/Rybka.cpp
@@ -1327,6 +1327,12 @@ void Rybka::OptionIn( const char *s )
 
     // max_cpu_cores
     parm = str_pattern_smart(s,"nbr|number|max|maximum*processors|cpus|cores");
+    if (!parm)
+    {
+        // alternative check for StockFish, which also has "Max Threads per Split Point",
+        // and str_pattern_smart() isn't quite smart enough to discriminate ;)
+        parm = str_pattern(s, "Threads", true);
+    }
     if( parm && str_search(parm,"type spin",true) )
     {
         memset( max_cpu_cores_name, 0, sizeof(max_cpu_cores_name) );

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -159,6 +159,8 @@ public:
         void OnUpdateEditDelete( wxUpdateUIEvent &);
     void OnEditGameDetails (wxCommandEvent &);
         void OnUpdateEditGameDetails( wxUpdateUIEvent &);
+    void OnEditCopyGamePGNToClipboard (wxCommandEvent &);
+        void OnUpdateEditCopyGamePGNToClipboard(wxUpdateUIEvent &);
     void OnEditPromote (wxCommandEvent &);
         void OnUpdateEditPromote( wxUpdateUIEvent &);
     void OnEditDemote (wxCommandEvent &);
@@ -342,6 +344,8 @@ BEGIN_EVENT_TABLE(ChessFrame, wxFrame)
         EVT_UPDATE_UI (wxID_DELETE,                     ChessFrame::OnUpdateEditDelete)
     EVT_MENU (ID_EDIT_GAME_DETAILS,         ChessFrame::OnEditGameDetails)        
         EVT_UPDATE_UI (ID_EDIT_GAME_DETAILS,            ChessFrame::OnUpdateEditGameDetails)
+    EVT_MENU(ID_COPY_GAME_PGN_TO_CLIPBOARD,              ChessFrame::OnEditCopyGamePGNToClipboard)
+        EVT_UPDATE_UI(ID_COPY_GAME_PGN_TO_CLIPBOARD,                 ChessFrame::OnUpdateEditCopyGamePGNToClipboard)
     EVT_MENU (ID_EDIT_PROMOTE,              ChessFrame::OnEditPromote)        
         EVT_UPDATE_UI (ID_EDIT_PROMOTE,                 ChessFrame::OnUpdateEditPromote)
     EVT_MENU (ID_EDIT_DEMOTE,               ChessFrame::OnEditDemote)    
@@ -408,6 +412,7 @@ ChessFrame::ChessFrame(const wxString& title, const wxPoint& pos, const wxSize& 
     menu_edit->Append (wxID_REDO,                    _T("Redo\tCtrl+Y"));
     menu_edit->Append (wxID_DELETE,                  _T("Delete comment text or remainder of variation\tDel"));
     menu_edit->Append (ID_EDIT_GAME_DETAILS,         _T("Edit game details"));
+    menu_edit->Append (ID_COPY_GAME_PGN_TO_CLIPBOARD,     _T("Copy game to clipboard (PGN)"));
     menu_edit->Append (ID_EDIT_PROMOTE,              _T("Promote variation"));
     menu_edit->Append (ID_EDIT_DEMOTE,               _T("Demote variation"));
     menu_edit->Append (ID_EDIT_DEMOTE_TO_COMMENT,    _T("Demote rest of variation to comment"));
@@ -967,6 +972,11 @@ void ChessFrame::OnEditGameDetails (wxCommandEvent &)
     objs.gl->CmdEditGameDetails();
 }
 
+void ChessFrame::OnEditCopyGamePGNToClipboard(wxCommandEvent &)
+{
+    objs.gl->CmdEditCopyGamePGNToClipboard();
+}
+
 void ChessFrame::OnEditPromote (wxCommandEvent &)
 {
     objs.gl->CmdEditPromote();
@@ -1077,6 +1087,12 @@ void ChessFrame::OnUpdateEditDelete( wxUpdateUIEvent &event )
 }
 
 void ChessFrame::OnUpdateEditGameDetails( wxUpdateUIEvent &event )
+{
+    bool enabled = true;
+    event.Enable(enabled);
+}
+
+void ChessFrame::OnUpdateEditCopyGamePGNToClipboard(wxUpdateUIEvent &event)
 {
     bool enabled = true;
     event.Enable(enabled);
@@ -1197,7 +1213,7 @@ void ChessFrame::OnPlayWhite (wxCommandEvent &)
 
 void ChessFrame::OnPlayBlack (wxCommandEvent &)
 {
-    objs.gl->CmdPlayWhite();
+    objs.gl->CmdPlayBlack();
 }
 
 void ChessFrame::OnSwapSides (wxCommandEvent &)


### PR DESCRIPTION
Hi Bill, this PR includes all the changes made previously in trunk for a 2.02b release, namely:
- The _Play Black_ bug is fixed
- The new _Copy Game to Clipboard (PGN)_ feature
- A fix to ensure the `Set Max CPU Cores` option is set correctly for StockFish
- A typo in `src\CtrlBox2.cpp` that prevented compilation has been fixed
